### PR TITLE
Trim documentation 

### DIFF
--- a/src/attribute_parser.ml
+++ b/src/attribute_parser.ml
@@ -86,6 +86,14 @@ let to_expr name = function
 
 let to_expr_opt name = Option.map (to_expr name)
 
+let to_trimmed_string_expr name expr =
+  match expr with
+  | loc, [ { pstr_desc = Pstr_eval (expr, _); _ } ] ->
+      [%expr Stdlib.String.trim [%e expr]]
+  | loc, _ -> Error.attribute_payload ~loc name
+
+let to_trimmed_string_expr_opt name = Option.map (to_trimmed_string_expr name)
+
 module Term = struct
   type 'a t = {
     (* term *)

--- a/src/attribute_parser.mli
+++ b/src/attribute_parser.mli
@@ -6,6 +6,11 @@ val to_expr_opt :
   (Ppxlib.location * Ppxlib.structure) option ->
   Ppxlib.expression option
 
+val to_trimmed_string_expr_opt :
+  string ->
+  (Ppxlib.location * Ppxlib.structure) option ->
+  Ppxlib.expression option
+
 module Term : sig
   type 'a t = {
     (* term *)

--- a/src/group_cmds.ml
+++ b/src/group_cmds.ml
@@ -158,7 +158,7 @@ let cmd_vb_expr_of_const_decl
           |> Ast_builder.Default.estring ~loc:cd.pcd_name.loc
         in
         Info.expr_of_attrs ~loc default_name_expr cd.pcd_attributes
-        (* ('params -> 'result) * 'params Term.t *)
+      (* ('params -> 'result) * 'params Term.t *)
       and handle_expr, params_term_expr =
         handle_params_term_expr_of_const_decl func_expr cd
       in

--- a/src/term.ml
+++ b/src/term.ml
@@ -178,7 +178,7 @@ module Info = struct
           ("absent", Ap.to_expr_opt "absent" attrs.absent);
           ("docs", Ap.to_expr_opt "docs" attrs.docs);
           ("docv", Ap.to_expr_opt "docv" attrs.docv);
-          ("doc", Ap.to_expr_opt "doc" attrs.doc);
+          ("doc", Ap.to_trimmed_string_expr_opt "doc" attrs.doc);
           ("env", Cmd_env_info.expr_of_attrs ~loc attrs);
         ]
         |> List.filter_map (fun (name, expr_opt) ->

--- a/test/test_term_info.ml
+++ b/test/test_term_info.ml
@@ -3,7 +3,10 @@ open Ppx_subliner.Term.Info
 module Ap = Ppx_subliner.Attribute_parser.Term
 
 let loc = Location.none
-let test_gen = Utils.test_equal Utils.pp (expr_of_attrs ~loc [%expr [ "NAME" ]])
+
+let test_gen =
+  Utils.test_equal Ppxlib.Pprintast.expression
+    (expr_of_attrs ~loc [%expr [ "NAME" ]])
 
 let test_set =
   let u = (loc, [%str ()]) in
@@ -14,8 +17,8 @@ let test_set =
          [%expr Cmdliner.Cmd.Env.info ~deprecated:() ~docs:() ~doc:() ()]
        in
        [%expr
-         Cmdliner.Arg.info ~deprecated:() ~absent:() ~docs:() ~docv:() ~doc:()
-           ~env:[%e env_expr] [ "NAME" ]])
+         Cmdliner.Arg.info ~deprecated:() ~absent:() ~docs:() ~docv:()
+           ~doc:(Stdlib.String.trim ()) ~env:[%e env_expr] [ "NAME" ]])
       (Ap.make_t ~deprecated:u ~absent:u ~docs:u ~docv:u ~doc:u ~env:u
          ~env_deprecated:u ~env_docs:u ~env_doc:u ());
   ]


### PR DESCRIPTION
I write my docstrings using e.g.
```ocaml
type t = {
  name: string;
    (** Here is my documentation *)
}
```
Unfortunately, this produces the ocamldoc string `" Here is my documentation "` with surrounding spaces. This means that documentation generated by ppx_subliner is slightly ugly
```
OPTIONS
       --name=VAL (required)
            Some pretty long documentation, long enough that it is reformated
           automatically by ocamlformat to fit onto several lines
```
note the additional space on first line of doc.

There is a failing test, I've just spent like an hour trying to fix it but I don't know why it fails. I went to the trouble of printing the entire structure (by updating ppxlib and using the structure pretty printer in "full" mode), and the expected and received structure are strictly identical